### PR TITLE
Tests should not write logs

### DIFF
--- a/modules/text_processor.py
+++ b/modules/text_processor.py
@@ -115,14 +115,11 @@ class TextProcessor(object):
         keyword, child_name, date = self.get_data_from_message(message)
         if keyword in subscribe_keywords("English"):
             self.language = "English"
-            logging.info("Subscribing " + quote(message) + "...")
             action = self.process_subscribe
         elif keyword in subscribe_keywords("Hindi"):
             self.language = "Hindi"
-            logging.info("Subscribing " + quote(message) + "...")
             action = self.process_subscribe
         elif keyword == "stop":
-            logging.info("Unsubscribing " + quote(self.phone_number) + "...")
             action = self.process_unsubscribe
         else:
             logging.error("Keyword " + quote(keyword) + " in message " + quote(message) +
@@ -143,6 +140,11 @@ class TextProcessor(object):
             if date is None:
                 logging.error("Date in message " + quote(message) + " is invalid.")
                 action = self.process_failed_date
+
+        if action == self.process_subscribe:
+            logging.info("Subscribing " + quote(message) + "...")
+        elif action == self.process_unsubscribe:
+            logging.info("Unsubscribing " + quote(self.phone_number) + "...")
 
         response_text_message = action(child_name=child_name,
                                        date_of_birth=date)

--- a/tests/jobs/test_text_processor_job.py
+++ b/tests/jobs/test_text_processor_job.py
@@ -7,9 +7,10 @@ from modules.i18n import msg_subscribe, msg_unsubscribe, hindi_remind
 from jobs import text_processor_job
 
 class TextProcessorJobTests(TestCase):
+    @patch("logging.info")
     @patch("modules.text_reminder.Texter.send")
     @patch("jobs.text_processor_job.Texter.read_inbox")
-    def test_check_and_process_registrations(self, mocked_texter_read, mocked_texter_send):
+    def test_check_and_process_registrations(self, mocked_texter_read, mocked_texter_send, mocked_logger):
         mocked_texter_read.return_value = {'1-111-1111': ["JOIN ROLAND 29/5/2017"],
                                            '1-112-1111': [hindi_remind() + " SAI 29/5/2017",
                                                           "STOP"]}

--- a/tests/jobs/test_text_reminder_job.py
+++ b/tests/jobs/test_text_reminder_job.py
@@ -12,8 +12,9 @@ FAKE_NOW = datetime(2017, 7, 17, 0, 0)
 
 class TextReminderJobTests(TestCase):
     @freeze_time(FAKE_NOW)
+    @patch("logging.info")
     @patch("modules.text_reminder.Texter.send")
-    def test_remind_two_people(self, mocked_send_text):
+    def test_remind_two_people(self, mocked_send_text, mocked_logger):
         c1 = contact_object(name="Roland",
                             phone_number="1-111-1111",
                             date_of_birth="29/5/2017") # 6 weeks, 7 days ago
@@ -30,8 +31,9 @@ class TextReminderJobTests(TestCase):
         self.assertEqual(mocked_send_text.call_count, 2)
 
     @freeze_time(FAKE_NOW)
+    @patch("logging.info")
     @patch("modules.text_reminder.Texter.send")
-    def test_remind_two_people_but_not_the_cancelled_one(self, mocked_send_text):
+    def test_remind_two_people_but_not_the_cancelled_one(self, mocked_send_text, mocked_logger):
         c1 = contact_object(name="Roland",
                             phone_number="1-111-1111",
                             date_of_birth="29/5/2017") # 6 weeks, 7 days ago

--- a/tests/modules/test_text_reminder.py
+++ b/tests/modules/test_text_reminder.py
@@ -383,9 +383,10 @@ class TextReminderTests(TestCase):
         self.assertFalse(mocked_send_text.called)
 
     @freeze_time(FAKE_NOW)
+    @patch("logging.info")
     @patch("modules.text_reminder.Texter.send")
     @patch("modules.text_processor.Texter.send")
-    def test_remind_when_good_dont_remind_when_cancelled(self, r_mocked_send_text, t_mocked_send_text):
+    def test_remind_when_good_dont_remind_when_cancelled(self, r_mocked_send_text, t_mocked_send_text, mocked_logging):
         tr = text_reminder_object("29/5/2017") # 6 weeks, 7 days ago
         self.assertTrue(tr.should_remind_today())
         tp = TextProcessor(phone_number=tr.phone_number)


### PR DESCRIPTION
Mock `logging.info` correctly and consistently so that tests do not write out to the logfile.