### PR TITLE
Prettier server logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,16 @@ To verify the remote server is running correctly, run:
 python manage.py verify_server
 ```
 
-To read server logs:
+To read the last twenty server logs:
 
 ```
 python manage.py read_server_log
+```
+
+To download a copy of the server logs (downloaded to `logs/server_log.log`):
+
+```
+python manage.py fetch_server_log
 ```
 
 (To set up a new remote server, configure the server on AWS, edit the `REMOTE` file in `cshsms/settings.py`, and then run `fab install`. Don't do this unless you know what you are doing.)

--- a/fabfile.py
+++ b/fabfile.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager as _contextmanager
 from fabric.api import env, sudo, run, prefix, hide, settings
 from fabric.colors import green, red
 from fabric.context_managers import cd
-from fabric.operations import put
+from fabric.operations import put, get
 
 from cshsms.settings import DATABASES, REMOTE
 USER = DATABASES['default']['USER']
@@ -77,5 +77,13 @@ def verify_server():
 
 def read_server_log():
     with virtualenv():
-        run("cat logs/cshsms.log")
+        with hide('output', 'running', 'warnings'), settings(warn_only=True):
+            logs = run("head -n 20 logs/cshsms.log")
+            print(logs)
 
+def fetch_server_log():
+    with virtualenv():
+        with hide('output', 'running', 'warnings'), settings(warn_only=True):
+            print("Downloading server logs...")
+            get("logs/cshsms.log", "logs/server_log.log")
+            print("...Downloaded to `logs/server_log.log`")

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,7 +1,8 @@
 from __future__ import with_statement
 from contextlib import contextmanager as _contextmanager
 
-from fabric.api import env, sudo, run, prefix
+from fabric.api import env, sudo, run, prefix, hide, settings
+from fabric.colors import green, red
 from fabric.context_managers import cd
 from fabric.operations import put
 
@@ -57,17 +58,24 @@ def deploy():
 
 def verify_server():
     with virtualenv():
-        print("Last deployment time was...")
-        run("env TZ=':America/Los_Angeles' date -r cshsms/settings.py")
-        print("Last log entry was...")
-        run("env TZ=':America/Los_Angeles' date -r logs/cshsms.log")
-        print("Last commit was...")
-        run("git log -1 --format=%cd | cat")
-        print("Checking crontab...")
-        run("crontab -l")
+        with hide('output', 'running', 'warnings'), settings(warn_only=True):
+            last_deploy_time = run("env TZ=':America/Los_Angeles' date -r cshsms/settings.py")
+            print("Last deployment time was {}.".format(last_deploy_time))
+            last_log_entry_time = run("env TZ=':America/Los_Angeles' date -r logs/cshsms.log")
+            print("Last log entry was {}.".format(last_log_entry_time))
+            last_commit_time = run("git log -1 --format=%cd | cat")
+            print("Last commit was {}.".format(last_commit_time))
+            crontab = run("crontab -l")
+            if len(crontab) == 0:
+                print(red("Crontab is offline!"))
+            else:
+                print(green("Crontab installed and running..."))
+                print(crontab)
         print("Verifying remote tests...")
         run("python manage.py test")
+
 
 def read_server_log():
     with virtualenv():
         run("cat logs/cshsms.log")
+

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import sys
 from fabric.context_managers import settings
 
 from cshsms.settings import REMOTE
-from fabfile import deploy, verify_server, read_server_log
+from fabfile import deploy, verify_server, read_server_log, fetch_server_log
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cshsms.settings")
@@ -34,5 +34,7 @@ if __name__ == "__main__":
             verify_server()
         elif sys.argv[1] == "read_server_log":
             read_server_log()
+        elif sys.argv[1] == "fetch_server_log":
+            fetch_server_log()
         else:
             execute_from_command_line(sys.argv)


### PR DESCRIPTION
`python manage.py verify_server` now has clearer and more concise output.
`python manage.py read_server_log` now has more concise output and only fetches the latest 20 entries.
`python manage.py fetch_server_log` downloads a local copy of the entire server log.