### PR TITLE
Swap STOP to END

### DIFF
--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -3,9 +3,9 @@ from cshsms.settings import TEXTLOCAL_PHONENUMBER
 
 def msg_subscribe(language):
     if language == "English":
-        return "{name} has been subscribed to CSH health reminders. Text STOP to " + TEXTLOCAL_PHONENUMBER + " to unsubscribe."
+        return "{name} has been subscribed to CSH health reminders. Text END to " + TEXTLOCAL_PHONENUMBER + " to unsubscribe."
     elif language == "Hindi":
-        return u'{name} \u0938\u0940 \u090f\u0938 \u090f\u091a \u0939\u0947\u0932\u094d\u0925 \u0905\u0928\u0941\u0938\u094d\u092e\u0930\u0928 \u0915\u0947 \u0938\u0926\u0938\u094d\u092f \u0939\u0948\u0902. \u0938\u0926\u0938\u094d\u092f\u0924\u093e \u0930\u0926\u094d\u0926 \u0915\u0930\u0928\u0947 \u0915\u0947 \u0932\u093f\u090f \u0932\u093f\u0916\u0947\u0902 "STOP" \u0914\u0930 \u092d\u0947\u0902\u091c \u0926\u0947 ' + TEXTLOCAL_PHONENUMBER + ' \u092a\u0930.'
+        return u'{name} \u0938\u0940 \u090f\u0938 \u090f\u091a \u0939\u0947\u0932\u094d\u0925 \u0905\u0928\u0941\u0938\u094d\u092e\u0930\u0928 \u0915\u0947 \u0938\u0926\u0938\u094d\u092f \u0939\u0948\u0902. \u0938\u0926\u0938\u094d\u092f\u0924\u093e \u0930\u0926\u094d\u0926 \u0915\u0930\u0928\u0947 \u0915\u0947 \u0932\u093f\u090f \u0932\u093f\u0916\u0947\u0902 "END" \u0914\u0930 \u092d\u0947\u0902\u091c \u0926\u0947 ' + TEXTLOCAL_PHONENUMBER + ' \u092a\u0930.'
 
 
 def msg_unsubscribe(language):
@@ -32,9 +32,9 @@ def msg_placeholder_child(language):
 
 def msg_failure(language):
     if language == "English":
-        return "Sorry, we didn't understand that message. Text STOP to " + TEXTLOCAL_PHONENUMBER + " to unsubscribe."
+        return "Sorry, we didn't understand that message. Text END to " + TEXTLOCAL_PHONENUMBER + " to unsubscribe."
     elif language == "Hindi":
-        return u'\u0915\u094d\u0937\u092e\u093e \u0915\u0930\u0947\u0902, \u0939\u092e\u0928\u0947 \u0909\u0938 \u0938\u0902\u0926\u0947\u0936 \u0915\u094b \u0928\u0939\u0940\u0902 \u0938\u092e\u091d\u093e. \u0938\u0926\u0938\u094d\u092f\u0924\u093e \u0930\u0926\u094d\u0926 \u0915\u0930\u0928\u0947 \u0915\u0947 \u0932\u093f\u090f \u0932\u093f\u0916\u0947\u0902 "STOP" \u0914\u0930 \u092d\u0947\u0902\u091c \u0926\u0947 ' + TEXTLOCAL_PHONENUMBER + ' \u092a\u0930.'
+        return u'\u0915\u094d\u0937\u092e\u093e \u0915\u0930\u0947\u0902, \u0939\u092e\u0928\u0947 \u0909\u0938 \u0938\u0902\u0926\u0947\u0936 \u0915\u094b \u0928\u0939\u0940\u0902 \u0938\u092e\u091d\u093e. \u0938\u0926\u0938\u094d\u092f\u0924\u093e \u0930\u0926\u094d\u0926 \u0915\u0930\u0928\u0947 \u0915\u0947 \u0932\u093f\u090f \u0932\u093f\u0916\u0947\u0902 "END" \u0914\u0930 \u092d\u0947\u0902\u091c \u0926\u0947 ' + TEXTLOCAL_PHONENUMBER + ' \u092a\u0930.'
 
 
 def msg_failed_date(language):

--- a/modules/text_processor.py
+++ b/modules/text_processor.py
@@ -119,7 +119,7 @@ class TextProcessor(object):
         elif keyword in subscribe_keywords("Hindi"):
             self.language = "Hindi"
             action = self.process_subscribe
-        elif keyword == "stop":
+        elif keyword == "end":
             action = self.process_unsubscribe
         else:
             logging.error("Keyword " + quote(keyword) + " in message " + quote(message) +

--- a/tests/jobs/test_text_processor_job.py
+++ b/tests/jobs/test_text_processor_job.py
@@ -13,7 +13,7 @@ class TextProcessorJobTests(TestCase):
     def test_check_and_process_registrations(self, mocked_texter_read, mocked_texter_send, mocked_logger):
         mocked_texter_read.return_value = {'1-111-1111': ["JOIN ROLAND 29/5/2017"],
                                            '1-112-1111': [hindi_remind() + " SAI 29/5/2017",
-                                                          "STOP"]}
+                                                          "END"]}
         text_processor_job.check_and_process_registrations()
         calls = [call(message=msg_subscribe("English").format(name="Roland"),
                       phone_number="1-111-1111"),

--- a/tests/modules/test_text_processor.py
+++ b/tests/modules/test_text_processor.py
@@ -80,10 +80,10 @@ class TextProcessorGetDataTests(TestCase):
         self.assertEqual(child_name, None)
         self.assertEqual(date, datetime(2015, 11, 25, 0, 0).date())
 
-    def test_stop(self):
+    def test_end(self):
         t = TextProcessor(phone_number="1-111-1111")
-        keyword, child_name, date = t.get_data_from_message("STOP")
-        self.assertEqual(keyword, "stop")
+        keyword, child_name, date = t.get_data_from_message("END")
+        self.assertEqual(keyword, "end")
         self.assertEqual(child_name, None)
         self.assertEqual(date, None)
 
@@ -178,7 +178,7 @@ class TextProcessorProcessTests(TestCase):
     def test_unsubscribe_english(self, texting_mock, logging_mock):
         t = TextProcessor(phone_number="1-111-1112")
         t.process("JOIN Roland 12/11/2017")
-        response = t.process("STOP")
+        response = t.process("END")
         self.assertTrue(t.get_contacts().first().cancelled)
         self.assertEqual(response, msg_unsubscribe("English"))
         logging_mock.assert_called_with("Unsubscribing `1-111-1112`...")
@@ -196,7 +196,7 @@ class TextProcessorProcessTests(TestCase):
                                language_preference="Hindi",
                                method_of_sign_up="Text")
         t = TextProcessor(phone_number="1-112-1112")
-        response = t.process("STOP")
+        response = t.process("END")
         self.assertTrue(t.get_contacts().first().cancelled)
         self.assertEqual(response, msg_unsubscribe("Hindi"))
         logging_mock.assert_called_with("Unsubscribing `1-112-1112`...")
@@ -208,7 +208,7 @@ class TextProcessorProcessTests(TestCase):
     def test_unsubscribe_without_contact(self, texting_mock, logging_info_mock, logging_error_mock):
         self.assertFalse(Contact.objects.filter(phone_number="1-111-1112").exists())
         t = TextProcessor(phone_number="1-111-1112")
-        response = t.process("STOP")
+        response = t.process("END")
         self.assertFalse(Contact.objects.filter(phone_number="1-111-1112").exists())
         self.assertEqual(response, msg_unsubscribe("English"))
         logging_error_mock.assert_called_with("`1-111-1112` asked to be unsubscribed but does not exist.")
@@ -290,7 +290,7 @@ class TextProcessorProcessTests(TestCase):
         self.assertEqual(contacts.count(), 1)
         self.assertFalse(contacts.first().cancelled)
         t2 = TextProcessor(phone_number="1-111-1116")
-        t2.process("STOP")
+        t2.process("END")
         contacts = Contact.objects.filter(name="Rob", phone_number="1-111-1116")
         self.assertTrue(contacts.exists())
         self.assertTrue(contacts.first().cancelled)
@@ -308,7 +308,7 @@ class TextProcessorProcessTests(TestCase):
         self.assertTrue(contacts.exists())
         self.assertFalse(contacts.first().cancelled)
         t2 = TextProcessor(phone_number="1-111-1117")
-        t2.process("STOP")
+        t2.process("END")
         contacts = Contact.objects.filter(name="Cheyenne", phone_number="1-111-1117")
         self.assertTrue(contacts.exists())
         self.assertTrue(contacts.first().cancelled)
@@ -331,7 +331,7 @@ class TextProcessorProcessTests(TestCase):
         self.assertTrue(contacts.exists())
         self.assertEqual(contacts.first().date_of_birth, datetime(2012, 11, 25, 0, 0).date())
         t2 = TextProcessor(phone_number="1-111-1118")
-        t2.process("STOP")
+        t2.process("END")
         contacts = Contact.objects.filter(name="Cheyenne", phone_number="1-111-1118")
         self.assertTrue(contacts.exists())
         self.assertEqual(contacts.first().date_of_birth, datetime(2012, 11, 25, 0, 0).date())
@@ -355,7 +355,7 @@ class TextProcessorProcessTests(TestCase):
         self.assertTrue(contacts.exists())
         self.assertEqual(contacts.first().language_preference, "English")
         t2 = TextProcessor(phone_number="1-111-1118")
-        t2.process("STOP")
+        t2.process("END")
         t3 = TextProcessor(phone_number="1-111-1118")
         third_response = t.process(hindi_remind() + " LARISSA 25-11-2012")
         self.assertEqual(third_response, msg_subscribe("Hindi").format(name="Larissa"))

--- a/tests/modules/test_text_reminder.py
+++ b/tests/modules/test_text_reminder.py
@@ -466,6 +466,6 @@ class TextReminderTests(TestCase):
         tr = text_reminder_object("12/6/2017") # 7 days before the 6 week appointment
         self.assertTrue(tr.should_remind_today())
         tp = TextProcessor(phone_number=tr.phone_number)
-        tp.process("STOP")
+        tp.process("END")
         self.assertTrue("Contact is cancelled." in tr.why_not_remind_reasons())
         self.assertFalse(tr.should_remind_today())


### PR DESCRIPTION
TextLocal will hard stop any phone number that texts "STOP", preventing us from being able to capture this data. We want people to unsubscribe using "END" instead.