### PR TITLE
Be able to quote a message that is not a string

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -2,7 +2,7 @@ import re
 from management.models import Group
 
 def quote(word):
-    return "`" + word + "`"
+    return u"`{}`".format(word)
 
 
 def add_contact_to_group(contact, group_name):

--- a/tests/modules/test_utils.py
+++ b/tests/modules/test_utils.py
@@ -15,6 +15,9 @@ class QuoteTests(TestCase):
     def test_quote(self):
         self.assertEqual(quote("text"), "`text`")
 
+    def test_quote_with_a_float(self):
+        self.assertEqual(quote(2.0), "`2.0`")
+
 
 class DateIsValidTests(TestCase):
     def test_normal_date(self):


### PR DESCRIPTION
Resolves this error:

```
 2017-10-07 00:00:02,435 | ERROR | crontab.py:147 | Failed to complete cronjob at ('*/10 * * * *', 'jobs.text_processor_job.check_and_process_registrations')
 Traceback (most recent call last):
   File "/home/ubuntu/.virtualenvs/csh/local/lib/python2.7/site-packages/django_crontab/crontab.py", line 145, in run_job
     func(*job_args, **job_kwargs)
   File "/home/ubuntu/csh-sms/jobs/text_processor_job.py", line 14, in check_and_process_registrations
     t.process(text)
   File "/home/ubuntu/csh-sms/modules/text_processor.py", line 154, in process
     logging.info("Unsubscribing " + quote(self.phone_number) + "...")
   File "/home/ubuntu/csh-sms/modules/utils.py", line 5, in quote
     return "`" + word + "`"
TypeError: cannot concatenate 'str' and 'int' objects
```